### PR TITLE
Feature/track sequencer addr

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+on:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+      - update-external-dependencies
+      - 'release/**'
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Lint
+        run: |
+          make install-linter
+          make lint

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,0 +1,37 @@
+---
+name: Test e2e
+on:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+      - update-external-dependencies
+      - 'release/**'
+  pull_request:
+
+jobs:
+  test-e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [ 1.19.x ]
+        goarch: [ "amd64" ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+      env:
+        GOARCH: ${{ matrix.goarch }}
+
+    - name: Build Docker
+      run: make build-docker
+
+    - name: Test
+      run: make test-e2e
+      working-directory: test

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,0 +1,34 @@
+---
+name: Test unit
+on:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+      - update-external-dependencies
+      - 'release/**'
+  pull_request:
+
+jobs:
+  test-unit:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [ 1.19.x ]
+        goarch: [ "amd64" ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+      env:
+        GOARCH: ${{ matrix.goarch }}
+
+    - name: Test
+      run: make test-unit
+      working-directory: test

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ else
 endif
 GOBASE := $(shell pwd)
 GOBIN := $(GOBASE)/dist
-GOENVVARS := GOBIN=$(GOBIN) CGO_ENABLED=0 GOOS=darwin GOARCH=$(ARCH)
+GOENVVARS := GOBIN=$(GOBIN) CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH)
 GOBINARY := supernets2.0-data-availability
 GOCMD := $(GOBASE)/cmd
 

--- a/config/config.go
+++ b/config/config.go
@@ -23,11 +23,18 @@ const (
 
 // Config represents the full configuration of the data node
 type Config struct {
-	SequencerAddr string `mapstructure:"SequencerAddr"`
-	PrivateKey    types.KeystoreFileConfig
-	DB            db.Config
-	Log           log.Config
-	RPC           jsonrpc.Config
+	PrivateKey types.KeystoreFileConfig
+	DB         db.Config
+	Log        log.Config
+	RPC        jsonrpc.Config
+	L1         L1Config
+}
+
+type L1Config struct {
+	WsURL       string         `mapstructure:"WsURL"`
+	Contract    string         `mapstructure:"Contract"`
+	Timeout     types.Duration `mapstructure:"Timeout"`
+	RetryPeriod types.Duration `mapstructure:"RetryPeriod"`
 }
 
 // Load loads the configuration baseed on the cli context

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	L1         L1Config
 }
 
+// L1Config is a struct that defines L1 contract and service settings
 type L1Config struct {
 	WsURL       string         `mapstructure:"WsURL"`
 	Contract    string         `mapstructure:"Contract"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xPolygonHermez/zkevm-node/config/types"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func Test_Defaults(t *testing.T) {
+	tcs := []struct {
+		path          string
+		expectedValue interface{}
+	}{
+		{
+			path:          "L1.WsURL",
+			expectedValue: "ws://localhost:8546",
+		},
+		{
+			path:          "L1.Contract",
+			expectedValue: "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+		},
+		{
+			path:          "L1.Timeout",
+			expectedValue: types.NewDuration(1 * time.Minute),
+		},
+		{
+			path:          "L1.RetryPeriod",
+			expectedValue: types.NewDuration(5 * time.Second),
+		},
+		// TODO: more default checks
+	}
+
+	ctx := cli.NewContext(cli.NewApp(), nil, nil)
+	cfg, err := Load(ctx)
+	require.NoError(t, err)
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			actual := getValueFromStruct(tc.path, cfg)
+			require.Equal(t, tc.expectedValue, actual)
+		})
+	}
+}
+
+func getValueFromStruct(path string, object interface{}) interface{} {
+	keySlice := strings.Split(path, ".")
+	v := reflect.ValueOf(object)
+
+	for _, key := range keySlice {
+		for v.Kind() == reflect.Ptr {
+			v = v.Elem()
+		}
+
+		v = v.FieldByName(key)
+	}
+	return v.Interface()
+}

--- a/config/default.go
+++ b/config/default.go
@@ -9,8 +9,13 @@ import (
 
 // DefaultValues is the default configuration
 const DefaultValues = `
-SequencerAddr = "0xf39Fd651aad88F6F4ce6aB8827279cffFb92266"
 PrivateKey = {Path = "/pk/test-member.keystore", Password = "testonly"}
+
+[L1]
+WsURL = "ws://localhost:8546"
+Contract = "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
+Timeout = "1m"
+RetryPeriod = "5s"
 
 [Log]
 Environment = "development" # "production" or "development"

--- a/services/datacom/tracker.go
+++ b/services/datacom/tracker.go
@@ -1,0 +1,127 @@
+package datacom
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/0xPolygon/supernets2.0-data-availability/config"
+	"github.com/0xPolygonHermez/zkevm-node/etherman"
+	"github.com/0xPolygonHermez/zkevm-node/etherman/smartcontracts/polygonzkevm"
+	"github.com/0xPolygonHermez/zkevm-node/log"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// SequencerTracker watches the contract for relevant changes to the sequencer
+type SequencerTracker struct {
+	client  *etherman.Client
+	addr    common.Address
+	stop    chan struct{}
+	lock    sync.Mutex
+	timeout time.Duration
+	retry   time.Duration
+}
+
+func NewSequencerTracker(cfg config.L1Config) (*SequencerTracker, error) {
+	client, err := newEtherman(cfg)
+	if err != nil {
+		return nil, err
+	}
+	// current address of the sequencer
+	addr, err := client.TrustedSequencer()
+	if err != nil {
+		return nil, err
+	}
+	w := &SequencerTracker{
+		client:  client,
+		addr:    addr,
+		stop:    make(chan struct{}),
+		timeout: cfg.Timeout.Duration,
+		retry:   cfg.RetryPeriod.Duration,
+	}
+	return w, nil
+}
+
+// newEtherman constructs an etherman client that only needs the free API calls to ZkEVMAddr contract
+func newEtherman(cfg config.L1Config) (*etherman.Client, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout.Duration)
+	defer cancel()
+	ethClient, err := ethclient.DialContext(ctx, cfg.WsURL)
+	if err != nil {
+		log.Errorf("error connecting to %s: %+v", cfg.WsURL, err)
+		return nil, err
+	}
+	zkEvm, err := polygonzkevm.NewPolygonzkevm(common.HexToAddress(cfg.Contract), ethClient)
+	if err != nil {
+		return nil, err
+	}
+	return &etherman.Client{
+		EthClient: ethClient,
+		ZkEVM:     zkEvm,
+	}, nil
+}
+
+func (st *SequencerTracker) GetAddr() common.Address {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	return st.addr
+}
+
+func (st *SequencerTracker) setAddr(addr common.Address) {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	st.addr = addr
+}
+
+func (st *SequencerTracker) Start() {
+	events := make(chan *polygonzkevm.PolygonzkevmSetTrustedSequencer)
+	defer close(events)
+	for {
+		var (
+			sub event.Subscription = nil
+			err error              = nil
+		)
+
+		ctx, cancel := context.WithTimeout(context.Background(), st.timeout)
+		opts := &bind.WatchOpts{Context: ctx}
+		sub, err = st.client.ZkEVM.WatchSetTrustedSequencer(opts, events)
+
+		// if no subscription, retry until established
+		for sub == nil {
+			log.Warn("retrying event subscription")
+			select {
+			case <-time.After(st.retry):
+				sub, err = st.client.ZkEVM.WatchSetTrustedSequencer(opts, events)
+				if err != nil {
+					log.Errorf("error subscribing to trusted sequencer event, retrying", err)
+				}
+			}
+		}
+
+		// wait on events, timeouts, and signals to stop
+		select {
+		case e := <-events:
+			log.Infof("new trusted sequencer address: {}", e.NewTrustedSequencer)
+			st.setAddr(e.NewTrustedSequencer)
+		case err := <-sub.Err():
+			log.Warnf("subscription error, resubscribing", err)
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				log.Debug("re-establishing subscription after timeout")
+			}
+		case <-st.stop:
+			if sub != nil {
+				sub.Unsubscribe()
+			}
+			cancel()
+			return
+		}
+	}
+}
+
+func (st *SequencerTracker) Stop() {
+	close(st.stop)
+}

--- a/services/datacom/tracker.go
+++ b/services/datacom/tracker.go
@@ -93,7 +93,7 @@ func (st *SequencerTracker) Start() {
 		sub, err = st.client.ZkEVM.WatchSetTrustedSequencer(opts, events)
 
 		// if no subscription, retry until established
-		for sub == nil {
+		for err != nil {
 			<-time.After(st.retry)
 			sub, err = st.client.ZkEVM.WatchSetTrustedSequencer(opts, events)
 			if err != nil {

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,6 +14,13 @@ run-local: ## Runs a full data node
 	docker compose up -d supernets2.0-data-availability-db
 	go run ../cmd run --cfg config/test.local.toml
 
+.PHONY: zkevm-mock-l1-network
+zkevm-mock-l1-network: ## Run the zklidium contracts
+	docker compose up -d zkevm-mock-l1-network
+
+.PHONY: run-deps
+run-deps: zkevm-mock-l1-network run-db
+
 .PHONY: stop
 stop: ## Stop a full data node
 	$(STOP)

--- a/test/Makefile
+++ b/test/Makefile
@@ -32,6 +32,5 @@ test-e2e: stop ## Runs the E2E tests
 	trap '$(STOP)' EXIT; MallocNanoZone=0 go test -count=1 -race -v -p 1 -timeout 600s ./e2e/...
 
 .PHONY: test-unit
-test-unit: stop ## Runs the unit tests
-	$(RUN-DB)
-	trap '$(STOP)' EXIT; MallocNanoZone=0 go test -count=1 -short -race -v -p 1 -timeout 600s ../...
+test-unit: ## Runs the unit tests, skips e2e
+	go test `go list ../... | grep -v /e2e`

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,21 +5,22 @@ RUN-DB := docker compose up -d supernets2.0-data-availability-db
 run: ## Runs a full data node
 	docker compose up -d
 
-.PHONY: run-db
-run-db: ## Runs a full data node
-	$(RUN-DB)
-
 .PHONY: run-local
 run-local: ## Runs a full data node
 	docker compose up -d supernets2.0-data-availability-db
+	docker compose up -d zkevm-mock-l1-network
 	go run ../cmd run --cfg config/test.local.toml
+
+.PHONY: run-db
+run-db: ## Runs the data store
+	$(RUN-DB)
 
 .PHONY: zkevm-mock-l1-network
 zkevm-mock-l1-network: ## Run the zklidium contracts
 	docker compose up -d zkevm-mock-l1-network
 
 .PHONY: run-deps
-run-deps: zkevm-mock-l1-network run-db
+run-deps: zkevm-mock-l1-network run-db # run the service dependencies
 
 .PHONY: stop
 stop: ## Stop a full data node

--- a/test/config/test.docker.toml
+++ b/test/config/test.docker.toml
@@ -1,5 +1,10 @@
-SequencerAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 PrivateKey = {Path = "/pk/test-member.keystore", Password = "testonly"}
+
+[L1]
+WsURL = "ws://zkevm-mock-l1-network:8546"
+Contract = "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
+Timeout = "3m"
+RetryPeriod = "5s"
 
 [Log]
 Environment = "development" # "production" or "development"

--- a/test/config/test.local.toml
+++ b/test/config/test.local.toml
@@ -1,5 +1,10 @@
-SequencerAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 PrivateKey = {Path = "config/test-member.keystore", Password = "testonly"}
+
+[L1]
+WsURL = "ws://localhost:8546"
+Contract = "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
+Timeout = "3m"
+RetryPeriod = "5s"
 
 [Log]
 Environment = "development" # "production" or "development"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -46,3 +46,36 @@ services:
       - "postgres"
       - "-N"
       - "500"
+        
+  zkevm-mock-l1-network:
+    container_name: zkevm-mock-l1-network
+    image: hermeznetwork/geth-zklidium-contracts:v0.0.3
+    healthcheck:
+      test: [ "CMD-SHELL", "geth attach --datadir /geth_data --exec eth.blockNumber" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - 8545:8545
+      - 8546:8546
+    command:
+      - "--http"
+      - "--http.api"
+      - "admin,eth,debug,miner,net,txpool,personal,web3"
+      - "--http.addr"
+      - "0.0.0.0"
+      - "--http.corsdomain"
+      - "*"
+      - "--http.vhosts"
+      - "*"
+      - "--ws"
+      - "--ws.origins"
+      - "*"
+      - "--ws.addr"
+      - "0.0.0.0"
+      - "--dev"
+      - "--datadir"
+      - "/geth_data"
+      - "--syncmode"
+      - "full"
+      - "--rpc.allow-unprotected-txs"

--- a/test/e2e/tracker_test.go
+++ b/test/e2e/tracker_test.go
@@ -1,0 +1,30 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/0xPolygon/supernets2.0-data-availability/config"
+	"github.com/0xPolygon/supernets2.0-data-availability/services/datacom"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestTracker(t *testing.T) {
+	ctx := cli.NewContext(cli.NewApp(), nil, nil)
+	cfg, err := config.Load(ctx)
+	require.NoError(t, err)
+
+	tracker, err := datacom.NewSequencerTracker(cfg.L1)
+	require.NoError(t, err)
+
+	addr := tracker.GetAddr()
+	require.Equal(t, common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), addr)
+
+	go tracker.Start()
+	select {
+	case <-time.After(1 * time.Second):
+		tracker.Stop()
+	}
+}


### PR DESCRIPTION
This PR adds a sequencer tracker that consumes events from L1 when the sequencer address changes. It is resilient to reconnects. A L1 mock network docker resource has been added for e2e testing.