### PR TITLE
Close subscribers

### DIFF
--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -30,14 +30,14 @@ type BatchSynchronizer struct {
 	db        *db.DB
 	committee map[common.Address]etherman.DataCommitteeMember
 	lock      sync.Mutex
-	reorgs    <-chan ReorgBlock
+	reorgs    <-chan BlockReorg
 }
 
 const dbTimeout = 2 * time.Second
 const rpcTimeout = 3 * time.Second
 
 // NewBatchSynchronizer creates the BatchSynchronizer
-func NewBatchSynchronizer(cfg config.L1Config, self common.Address, db *db.DB, reorgs <-chan ReorgBlock) (*BatchSynchronizer, error) {
+func NewBatchSynchronizer(cfg config.L1Config, self common.Address, db *db.DB, reorgs <-chan BlockReorg) (*BatchSynchronizer, error) {
 	watcher, err := newWatcher(cfg)
 	if err != nil {
 		return nil, err

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,6 +11,10 @@ run-local: ## Runs a full data node
 	docker compose up -d supernets2-mock-l1-network
 	go run ../cmd run --cfg config/test.local.toml
 
+.PHONY: run-dev
+run-dev: run-db
+	go run ../cmd run --cfg config/test.dev.toml
+
 .PHONY: run-db
 run-db: ## Runs the data store
 	$(RUN-DB)


### PR DESCRIPTION
This PR fixes the ReorgDetector's Stop method so that it closes the subscriber channels. It also applies some minor refactoring.